### PR TITLE
Move react/native dependencies to dev to avoid conflicts and add platform check

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
   "dependencies": {
     "@livechat/chat.io-customer-sdk": "^0.8.0-2",
     "prop-types": "^15.6.0",
-    "react": "16.0.0-alpha.12",
-    "react-native": "0.48.1",
     "react-native-camera-roll-picker": "^1.2.3",
     "react-native-gifted-chat": "^0.3.0",
     "react-native-linear-gradient": "^2.3.0",
@@ -26,7 +24,9 @@
     "babel-jest": "21.2.0",
     "babel-preset-react-native": "4.0.0",
     "jest": "21.2.1",
-    "react-test-renderer": "16.0.0-alpha.12"
+    "react-test-renderer": "16.0.0-alpha.12",
+    "react": "16.0.0-alpha.12",
+    "react-native": "0.48.1"
   },
   "jest": {
     "preset": "react-native"

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -22,7 +22,7 @@ export default class HomeScreen extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <Header navigation={this.props.navigation} title="CHAT" />
+        {Platform.OS == 'ios'  && <Header navigation={this.props.navigation} title="CHAT" />}
         <View style={{
           flex: 1,
           alignItems: 'center',


### PR DESCRIPTION
There are bundling conflicts caused by having multiple sets of node_modules, so these are moved to devdependencies here. There is also a platform check added in home to not display the app bar on android since the navigation doesn't work for that platform - we just use native nav instead. 

@andyschwob 